### PR TITLE
[easy][inductor] already matched node do not need to match again in R…

### DIFF
--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -995,7 +995,7 @@ class RepeatedExpr(PatternExpr):
             self.inner_pattern,
         )
         # Check all anchor nodes match the pattern
-        for anchor_node in self.inner_pattern.find_anchor_nodes(ctx, OrderedSet()):
+        for anchor_node in self.inner_pattern.find_anchor_nodes(ctx, OrderedSet([node])):
             anchor_m = MatchContext([self], graph=node.graph).match(
                 self.inner_pattern, anchor_node
             )


### PR DESCRIPTION
…epeatedExpr

Otherwise, matched args, nodes, kwargs and targets would be doubled for the this match. Tested in our custom pass.